### PR TITLE
Do not import Data.Poly.gcdExt

### DIFF
--- a/test/Test/Poly.hs
+++ b/test/Test/Poly.hs
@@ -4,7 +4,7 @@ import Data.Curve.Weierstrass
 import Data.Curve.Weierstrass.BN254 (BN254, Fr)
 import Data.Euclidean (Euclidean (..))
 import Data.Pairing (Pairing (..))
-import Data.Poly (VPoly (..), eval, gcdExt, monomial, toPoly)
+import Data.Poly (VPoly (..), eval, monomial, toPoly)
 import Data.Vector (fromList)
 import Protocol.Groth (secretEvalInExponent)
 import Protolude hiding (rem)


### PR DESCRIPTION
`Test.Poly` imports `Data.Poly.gcdExt`, which is due to be removed from the next major release of `poly` as discussed elsewhere. This import is actually redundant (the module does not call `gcdExt` at all), so this PR just strips it from the import list.